### PR TITLE
Add error info to exception.to_s

### DIFF
--- a/lib/lms/canvas.rb
+++ b/lib/lms/canvas.rb
@@ -377,6 +377,8 @@ module LMS
       attr_reader :result
 
       def initialize(message = "", status = nil, result = nil)
+        super(message)
+
         @message = message
         @status = status
         @result = result

--- a/spec/canvas_spec.rb
+++ b/spec/canvas_spec.rb
@@ -5,7 +5,6 @@ require "lms_api"
 require "ostruct"
 require "thread"
 require "byebug"
-
 def thread_log(msg)
   print "[#{Thread.current.object_id}] #{msg}\n" if ENV["THREAD_LOG"]
 end
@@ -675,6 +674,14 @@ describe LMS::Canvas do
 
     end
 
+  end
+
+  describe "Exceptions" do
+    it "Should maintain information about failure in exception.to_s" do
+      message = "Nuclear Meltdown"
+      exception = LMS::Canvas::CanvasException.new(message)
+      expect(exception.to_s).to eq message
+    end
   end
 
 end


### PR DESCRIPTION
We add lots of useful data to exceptions when they occur. It is currently available by the `e.message`. The problem is that sometimes other tools assume that `to_s` will return the same result as `message`. This sometimes can leave you wondering what happened. This fix will rely on the built in `to_s` for `RuntimeError`, and make the data available in `message` also available if you call `to_s`.